### PR TITLE
codespaces環境でのDockerファイルの作成方法を変更する

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM toppersjp/hakoniwa-ecu-multiplay
+
+# If you want to build docker image, you can see dockerfile in 'hako/docker/Dockerfile'.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,10 @@
 
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"build": {
-		"dockerfile": "../hako/docker/Dockerfile",
+		"dockerfile": "Dockerfile"
 		// [Optional] You can use build args to set options. e.g. 'VARIANT' below affects the image in the Dockerfile
-		"context": "../hako/",	
-		"args": { "VARIANT": "buster" }	
+		// "context": "../hako/",	
+		// "args": { "VARIANT": "buster" }	
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/hako/docker/Dockerfile
+++ b/hako/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN bash build.bash
 
 WORKDIR /root
 RUN wget https://github.com/mitsut/cfg/releases/download/1.9.7/cfg-1.9.7-x86_64-unknown-linux-gnu.tar.gz && \
-	wget https://www.autosar.org/fileadmin/user_upload/standards/classic/4-0/AUTOSAR_MMOD_XMLSchema.zip && \
+	wget --no-check-certificate https://www.autosar.org/fileadmin/standards/classic/4-0/AUTOSAR_MMOD_XMLSchema.zip && \
 	mkdir schema && \
 	tar xvzf cfg-1.9.7-x86_64-unknown-linux-gnu.tar.gz && \
 	mv cfg schema/ && \

--- a/hako/docker/create-image.ps1
+++ b/hako/docker/create-image.ps1
@@ -1,0 +1,10 @@
+# PowerShell
+
+$ErrorActionPreference = "Stop"
+
+$IMAGE_NAME = Get-Content docker/image_name.txt
+$IMAGE_TAG = Get-Content appendix/latest_version.txt
+$DOCKER_IMAGE = $IMAGE_NAME+':'+$IMAGE_TAG
+$DOCKER_FILE = 'docker/Dockerfile'
+
+docker build -f $DOCKER_FILE -t $DOCKER_IMAGE .

--- a/hako/docker/push-image.ps1
+++ b/hako/docker/push-image.ps1
@@ -1,0 +1,12 @@
+# PowerShell
+
+$ErrorActionPreference = "Stop"
+
+$IMAGE_NAME = Get-Content docker/image_name.txt
+# $IMAGE_TAG = Get-Content appendix/latest_version.txt
+$IMAGE_TAG = 'latest'
+$DOCKER_IMAGE = $IMAGE_NAME+':'+$IMAGE_TAG
+
+docker tag $DOCKER_IMAGE $DOCKER_IMAGE
+docker login
+docker push $DOCKER_IMAGE


### PR DESCRIPTION
codespacesでDockerfileをビルドすると、最後の `build.bash` でエラーになってしまいました。
[RUN bash build.bash
](https://github.com/toppers/hakoniwa-ecu-multiplay/blob/04e8806e50e7192740b7d46b35fd798e62af5287/hako/docker/Dockerfile#L98)
ローカルPCでビルドすると問題がないので、ビルドイメージを作成し、devcontainerからはDocker Hubからイメージをダウンロードして使うように変更を行いました。

合わせてPowerShellでDockerのbuildとpushができるファイルを追加しました。