### PR TITLE
Migrate to GitHub Container Registry

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -9,9 +9,6 @@ on:
       - opened
       - synchronize
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -21,14 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Build image
-        run: |
-          set -e
-          cd hako
-          bash docker/create-image.bash
-          echo "✓ Successfully built ghcr.io/toppers/hakoniwa-ecu-multiplay:$(cat appendix/latest_version.txt)"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/v')
@@ -37,6 +30,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image with cache
+        run: |
+          set -e
+          cd hako
+          export DOCKER_BUILD_ARGS="--cache-from type=gha --cache-to type=gha,mode=max"
+          bash docker/create-image.bash
+          echo "✓ Successfully built ghcr.io/toppers/hakoniwa-ecu-multiplay:$(cat appendix/latest_version.txt)"
 
       - name: Push image to GHCR
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -2,8 +2,12 @@ name: Build and Push Container Image
 
 on:
   push:
-    tags:
-      - 'v*'
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
 
 jobs:
   build-and-push:
@@ -16,30 +20,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Build image
+        run: |
+          set -e
+          cd hako
+          bash docker/create-image.bash
+          echo "✓ Successfully built ghcr.io/toppers/hakoniwa-ecu-multiplay:$(cat appendix/latest_version.txt)"
+
       - name: Log in to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          # Validate version format (vX.Y.Z)
-          if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid version format: $VERSION. Expected vX.Y.Z"
-            exit 1
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building and pushing image: $VERSION"
-
-      - name: Build and push image
+      - name: Push image to GHCR
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           set -e
           cd hako
-          echo "${{ steps.version.outputs.VERSION }}" > appendix/latest_version.txt
-          bash docker/create-image.bash
           bash docker/push-image.bash
-          echo "✓ Successfully built and pushed ghcr.io/toppers/hakoniwa-ecu-multiplay:${{ steps.version.outputs.VERSION }}"
+          echo "✓ Successfully pushed ghcr.io/toppers/hakoniwa-ecu-multiplay:$(cat appendix/latest_version.txt)"

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -9,6 +9,9 @@ on:
       - opened
       - synchronize
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,45 @@
+name: Build and Push Container Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          # Validate version format (vX.Y.Z)
+          if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version format: $VERSION. Expected vX.Y.Z"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building and pushing image: $VERSION"
+
+      - name: Build and push image
+        run: |
+          set -e
+          cd hako
+          echo "${{ steps.version.outputs.VERSION }}" > appendix/latest_version.txt
+          bash docker/create-image.bash
+          bash docker/push-image.bash
+          echo "✓ Successfully built and pushed ghcr.io/toppers/hakoniwa-ecu-multiplay:${{ steps.version.outputs.VERSION }}"

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+CLAUDE*.md

--- a/hako/docker/README.md
+++ b/hako/docker/README.md
@@ -115,9 +115,9 @@ docker login ghcr.io
 
 **運用方針：**
 
-- 全ブランチでコンテナイメージをビルド（GitHub Actions）
+- 各ブランチへの push ではコンテナイメージをビルド（GitHub Actions）
 - git タグ（`v*.*.*`）作成時のみ GHCR にプッシュしてリリース
-- 他のブランチと PR ではビルド成功の確認のみ
+- PR は `main` 向けの場合のみビルド成功を確認
 - `hako/appendix/latest_version.txt` が version の source of truth
 
 **リリース手順：**

--- a/hako/docker/README.md
+++ b/hako/docker/README.md
@@ -8,14 +8,14 @@
 
 - **create-image.bash** - Dockerイメージを構築するスクリプト
 - **run.bash** - Dockerコンテナを起動するスクリプト
-- **pull-image.bash** - Docker Hubからイメージをプルするスクリプト
-- **push-image.bash** - Docker Hubにイメージをプッシュするスクリプト
+- **pull-image.bash** - GitHub Container Registry (GHCR) からイメージをプルするスクリプト
+- **push-image.bash** - GHCR にイメージをプッシュするスクリプト
 - **attach.bash** - 実行中のコンテナにアタッチするスクリプト
 
 ### PowerShellスクリプト (Windows用)
 
 - **create-image.ps1** - Dockerイメージを構築するPowerShellスクリプト
-- **push-image.ps1** - Docker HubにイメージをプッシュするPowerShellスクリプト
+- **push-image.ps1** - GHCR にイメージをプッシュするPowerShellスクリプト
 
 ### 設定ファイル
 
@@ -32,12 +32,24 @@
 
 ### 2. Dockerイメージの構築
 
-#### Linux/macOS
+**デフォルト:** git タグを作成すると GitHub Actions が自動的にビルド・プッシュします。以下のローカル実行は開発時のみ必要です。
+
+#### ローカルでのビルド (Linux/macOS)
+
 ```bash
 bash docker/create-image.bash
 ```
 
-#### Windows (PowerShell)
+このスクリプトは自動的に以下を実行します：
+
+- BuildKit を有効化（高速かつ効率的なビルド）
+- プラットフォームを `linux/amd64` に設定（Intel/Apple Silicon 対応）
+
+**macOS (Apple Silicon) での注意:**
+Intel ベースの環境と互換性を保つため、`linux/amd64` プラットフォームでビルドされます。
+
+#### ローカルでのビルド (Windows PowerShell)
+
 ```powershell
 .\docker\create-image.ps1
 ```
@@ -55,15 +67,24 @@ bash docker/run.bash
 
 ### 4. 実行中のコンテナにアタッチ
 
+#### 推奨: devContainer を使用
+
+VSCode で `.devcontainer/devcontainer.json` が自動的に検出されます。以下のいずれかの方法でアタッチできます：
+
+1. VSCode のコマンドパレット（Cmd/Ctrl + Shift + P）から `Dev Containers: Reopen in Container` を実行
+2. 左下の `><` アイコンをクリックして `Reopen in Container` を選択
+
+#### 代替方法: スクリプトを使用
+
 ```bash
 bash docker/attach.bash
 ```
 
-このスクリプトは実行中のコンテナを検索し、bash shellでアタッチします。
+このスクリプトは実行中のコンテナを検索し、bash shell でアタッチします。
 
 ### 5. イメージのプル
 
-Docker Hubから事前構築済みのイメージを取得：
+GitHub Container Registry (GHCR) から事前構築済みのイメージを取得：
 
 ```bash
 bash docker/pull-image.bash
@@ -81,7 +102,25 @@ bash docker/push-image.bash
 .\docker\push-image.ps1
 ```
 
-**注意**: プッシュするにはDocker Hubへのログインが必要です。
+**注意**: プッシュするには GHCR へのログインが必要です。
+
+```bash
+docker login ghcr.io
+```
+
+ログイン時には GitHub の Personal Access Token (PAT) を使用してください。
+詳細は [GitHub Container Registry ドキュメント](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) を参照してください。
+
+### 7. 自動ビルド・プッシュ (GitHub Actions)
+
+git タグを作成すると、GitHub Actions が自動的にイメージをビルドして GHCR にプッシュします：
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+これにより `ghcr.io/toppers/hakoniwa-ecu-multiplay:v1.2.0` が自動的に作成・プッシュされます。
 
 ## Dockerイメージについて
 

--- a/hako/docker/README.md
+++ b/hako/docker/README.md
@@ -113,14 +113,41 @@ docker login ghcr.io
 
 ### 7. 自動ビルド・プッシュ (GitHub Actions)
 
-git タグを作成すると、GitHub Actions が自動的にイメージをビルドして GHCR にプッシュします：
+**運用方針：**
+
+- 全ブランチでコンテナイメージをビルド（GitHub Actions）
+- git タグ（`v*.*.*`）作成時のみ GHCR にプッシュしてリリース
+- 他のブランチと PR ではビルド成功の確認のみ
+- `hako/appendix/latest_version.txt` が version の source of truth
+
+**リリース手順：**
+
+1. バージョンを更新
 
 ```bash
-git tag v1.2.0
-git push origin v1.2.0
+cd hako
+echo "v1.3.0" > appendix/latest_version.txt
+git add appendix/latest_version.txt
+git commit -m "Bump version to v1.3.0"
+git push origin main
 ```
 
-これにより `ghcr.io/toppers/hakoniwa-ecu-multiplay:v1.2.0` が自動的に作成・プッシュされます。
+1. タグを作成・プッシュ（リポジトリメンテナーのみ）
+
+```bash
+git tag v1.3.0
+git push origin v1.3.0
+```
+
+1. GitHub Actions が自動実行
+
+`ghcr.io/toppers/hakoniwa-ecu-multiplay:v1.3.0` が作成・プッシュされます
+
+**注意：**
+
+- 全ブランチと PR で GitHub Actions によるビルドが自動実行されます
+- GHCR へのプッシュは `v*.*.*` タグ作成時のみ
+- タグ作成前に `latest_version.txt` と一致していることを確認してください
 
 ## Dockerイメージについて
 

--- a/hako/docker/README.md
+++ b/hako/docker/README.md
@@ -15,7 +15,7 @@
 ### PowerShellスクリプト (Windows用)
 
 - **create-image.ps1** - Dockerイメージを構築するPowerShellスクリプト
-- **push-image.ps1** - GHCR にイメージをプッシュするPowerShellスクリプト
+- **push-image.ps1** - DockerイメージをプッシュするPowerShellスクリプト（現在の実装は Linux/macOS 用スクリプトと異なり、GHCR 向けログインや `appendix/latest_version.txt` を使ったバージョンタグ付けを前提としていません）
 
 ### 設定ファイル
 

--- a/hako/docker/create-image.bash
+++ b/hako/docker/create-image.bash
@@ -1,8 +1,22 @@
 #!/bin/bash
 
+set -e
+
 IMAGE_NAME=`cat docker/image_name.txt`
 IMAGE_TAG=`cat appendix/latest_version.txt`
 DOCKER_IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
 DOCKER_FILE=docker/Dockerfile
-docker build -t ${DOCKER_IMAGE} -f ${DOCKER_FILE} --build-arg HAKONIWA_VERSION=${IMAGE_TAG} .
+
+# Enable BuildKit for faster, more efficient builds
+export DOCKER_BUILDKIT=1
+
+# Use provided TARGETPLATFORM or default to linux/amd64
+TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
+
+docker build \
+  -t ${DOCKER_IMAGE} \
+  -f ${DOCKER_FILE} \
+  --build-arg HAKONIWA_VERSION=${IMAGE_TAG} \
+  --build-arg TARGETPLATFORM=${TARGETPLATFORM} \
+  .
 

--- a/hako/docker/create-image.bash
+++ b/hako/docker/create-image.bash
@@ -13,10 +13,15 @@ export DOCKER_BUILDKIT=1
 # Use provided TARGETPLATFORM or default to linux/amd64
 TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 
+# Additional docker build arguments (e.g., cache configuration from CI/CD)
+# Can be set via environment variable: DOCKER_BUILD_ARGS
+DOCKER_BUILD_ARGS=${DOCKER_BUILD_ARGS:-}
+
 docker build \
   -t ${DOCKER_IMAGE} \
   -f ${DOCKER_FILE} \
   --build-arg HAKONIWA_VERSION=${IMAGE_TAG} \
   --build-arg TARGETPLATFORM=${TARGETPLATFORM} \
+  ${DOCKER_BUILD_ARGS} \
   .
 

--- a/hako/docker/create-image.bash
+++ b/hako/docker/create-image.bash
@@ -17,7 +17,7 @@ TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 # Can be set via environment variable: DOCKER_BUILD_ARGS
 DOCKER_BUILD_ARGS=${DOCKER_BUILD_ARGS:-}
 
-docker build \
+docker buildx build \
   -t ${DOCKER_IMAGE} \
   -f ${DOCKER_FILE} \
   --build-arg HAKONIWA_VERSION=${IMAGE_TAG} \

--- a/hako/docker/image_name.txt
+++ b/hako/docker/image_name.txt
@@ -1,1 +1,1 @@
-toppersjp/hakoniwa-ecu-multiplay
+ghcr.io/toppers/hakoniwa-ecu-multiplay

--- a/hako/docker/push-image.bash
+++ b/hako/docker/push-image.bash
@@ -4,6 +4,16 @@ IMAGE_NAME=`cat docker/image_name.txt`
 IMAGE_TAG=`cat appendix/latest_version.txt`
 DOCKER_IMAGE=${IMAGE_NAME}:${IMAGE_TAG}
 
-docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE}
-docker login
+# Ensure logged in to GHCR
+if ! docker info > /dev/null 2>&1; then
+  echo "Error: Docker daemon is not accessible"
+  exit 1
+fi
+
+# For manual execution, ensure user is logged in
+if ! grep -q "ghcr.io" ~/.docker/config.json 2>/dev/null; then
+  echo "Not logged in to ghcr.io. Please run: docker login ghcr.io"
+  exit 1
+fi
+
 docker push ${DOCKER_IMAGE}


### PR DESCRIPTION
## Summary
- GitHub Container Registry (GHCR) へのDocker イメージ移行に対応
- Docker ビルド構成をローカルと GitHub Actions で統一
- Node.js 24 対応

## Changes
- GitHub Actions ワークフロー追加：`build-and-push-image.yml`
- Docker スクリプト更新：ビルド・プッシュロジックを統一
- ドキュメント拡張：Docker イメージビルド手順の詳細化
- CI/CD 最適化：全ブランチでビルド、リリースタグ時のみプッシュ

## Test plan
- [x] ローカルでの Docker ビルドが正常に動作すること
- [x] GitHub Actions ワークフローが正常に実行されること
- [x] GHCR へのプッシュが成功すること